### PR TITLE
Add hot install support for Magisk-compatible modules

### DIFF
--- a/apd/src/installer.sh
+++ b/apd/src/installer.sh
@@ -435,6 +435,16 @@ install_module() {
   $BOOTMODE || recovery_cleanup
   rm -rf $TMPDIR
 
+  # Hot install: run the module's hot install script if requested
+  if [ "$MODULE_HOT_INSTALL_REQUEST" = "true" ] && [ -n "$MODULE_HOT_RUN_SCRIPT" ]; then
+    if [ -f "$MODPATH/$MODULE_HOT_RUN_SCRIPT" ]; then
+      ui_print "- Running hot install: $MODULE_HOT_RUN_SCRIPT"
+      sh "$MODPATH/$MODULE_HOT_RUN_SCRIPT"
+    else
+      ui_print "- Hot install script not found: $MODULE_HOT_RUN_SCRIPT"
+    fi
+  fi
+
   ui_print "- Done"
 }
 

--- a/apd/src/module.rs
+++ b/apd/src/module.rs
@@ -43,6 +43,50 @@ pub enum ModuleType {
     Updated,
 }
 
+/// Extract customize.sh from a ZIP and parse MODULE_HOT_INSTALL_REQUEST / MODULE_HOT_RUN_SCRIPT
+fn extract_hot_install_vars(zip_path: &Path) -> (Option<String>, Option<String>) {
+    let file = match fs::File::open(zip_path) {
+        Ok(f) => f,
+        Err(_) => return (None, None),
+    };
+    let mut archive = match zip::ZipArchive::new(file) {
+        Ok(a) => a,
+        Err(_) => return (None, None),
+    };
+    let mut content = String::new();
+    if let Ok(mut entry) = archive.by_name("customize.sh") {
+        use std::io::Read;
+        let _ = entry.read_to_string(&mut content);
+    } else {
+        return (None, None);
+    }
+
+    let mut hot_request = None;
+    let mut hot_script = None;
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("export MODULE_HOT_INSTALL_REQUEST=") {
+            let val = trimmed["export MODULE_HOT_INSTALL_REQUEST=".len()..]
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
+            if !val.is_empty() {
+                hot_request = Some(val);
+            }
+        }
+        if trimmed.starts_with("export MODULE_HOT_RUN_SCRIPT=") {
+            let val = trimmed["export MODULE_HOT_RUN_SCRIPT=".len()..]
+                .trim_matches('"')
+                .trim_matches('\'')
+                .to_string();
+            if !val.is_empty() {
+                hot_script = Some(val);
+            }
+        }
+    }
+    (hot_request, hot_script)
+}
+
 fn exec_install_script(module_file: &str, is_metamodule: bool, module_id: &str) -> Result<()> {
     let realpath = std::fs::canonicalize(module_file)
         .with_context(|| format!("realpath: {module_file} failed"))?;
@@ -51,12 +95,25 @@ fn exec_install_script(module_file: &str, is_metamodule: bool, module_id: &str) 
     let install_script =
         metamodule::get_install_script(is_metamodule, INSTALLER_CONTENT, INSTALL_MODULE_SCRIPT)?;
 
-    let result = Command::new(assets::BUSYBOX_PATH)
-        .args(["sh", "-c", &install_script])
+    // Check if the module requests hot install
+    let zip_path = PathBuf::from(module_file);
+    let (hot_request, hot_script) = extract_hot_install_vars(&zip_path);
+
+    let mut cmd = Command::new(assets::BUSYBOX_PATH);
+    cmd.args(["sh", "-c", &install_script])
         .envs(get_common_script_envs(Some(module_id)))
         .env("OUTFD", "1")
-        .env("ZIPFILE", realpath)
-        .status()?;
+        .env("ZIPFILE", realpath);
+
+    // Pass hot install variables to the shell script if present
+    if let Some(ref val) = hot_request {
+        cmd.env("MODULE_HOT_INSTALL_REQUEST", val);
+    }
+    if let Some(ref val) = hot_script {
+        cmd.env("MODULE_HOT_RUN_SCRIPT", val);
+    }
+
+    let result = cmd.status()?;
     ensure!(result.success(), "Failed to install module script");
     Ok(())
 }


### PR DESCRIPTION
## Problem

Magisk-compatible modules like Tricky Addon use `MODULE_HOT_INSTALL_REQUEST` and `MODULE_HOT_RUN_SCRIPT` environment variables in their `customize.sh` to request immediate execution of post-install scripts (e.g., `hotinstall.sh`) without requiring a device reboot.

FolkPatch was not passing these variables through to the installer shell, so modules relying on hot install would not function correctly — their post-install scripts would never execute.

## Solution

Two minimal changes:

1. **`apd/src/module.rs`** — Added `extract_hot_install_vars()` function that parses `customize.sh` from the module ZIP to detect `MODULE_HOT_INSTALL_REQUEST` and `MODULE_HOT_RUN_SCRIPT`. These are then passed as environment variables to the installer shell command.

2. **`apd/src/installer.sh`** — At the end of `install_module()`, added a check: if `MODULE_HOT_INSTALL_REQUEST=true` and `MODULE_HOT_RUN_SCRIPT` is set, execute the specified script (typically `hotinstall.sh` which runs `post-fs-data.sh` and `service.sh`).

This matches the behavior expected by Magisk-compatible modules and follows the same pattern as mainline Magisk + APatch.