### PR TITLE
添加仪表盘壁纸恢复默认按钮+调整仪表卡片信息布局

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/component/BackgroundOptionsDialog.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/component/BackgroundOptionsDialog.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Restore
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.BasicAlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -68,6 +69,8 @@ fun BackgroundOptionsDialog(
     showBannerSection: Boolean = true,
     onSelectImage: () -> Unit,
     onClearImage: () -> Unit,
+    onRestoreDefault: (() -> Unit)? = null,   // 改为可空，默认 null
+    restoreLabel: String = "",                 // 改为默认空字符串
     // 模块信息相关（可选，不提供时不显示模块信息区域）
     customInfoTitle: String = "",
     customInfoNameLabel: String = "",
@@ -152,6 +155,22 @@ fun BackgroundOptionsDialog(
                                             text = selectLabel,
                                             modifier = Modifier.padding(start = 8.dp)
                                         )
+                                    }
+                                    //  恢复默认壁纸按钮（和"选择图片"风格一致）
+                                    if (onRestoreDefault != null) {
+                                        FilledTonalButton(
+                                            onClick = {
+                                                onDismiss()
+                                                onRestoreDefault()
+                                            },
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .height(52.dp),
+                                            shape = RoundedCornerShape(14.dp),
+                                        ) {
+                                            Icon(Icons.Default.Restore, contentDescription = null, modifier = Modifier.size(20.dp))
+                                            Text(text = restoreLabel, modifier = Modifier.padding(start = 8.dp))
+                                        }
                                     }
                                     // 清除按钮 — Outlined 风格，仅有已存在图片时显示
                                     if (hasExisting) {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/HomeV4.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/HomeV4.kt
@@ -484,7 +484,6 @@ private fun HeroStatusCard(
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween
                     ) {
                         VersionInfoColumn(
                             modifier = Modifier.weight(1f),
@@ -591,6 +590,12 @@ private fun HeroStatusCard(
                     markdown = false,
                 )
             },
+            // 新增：恢复默认壁纸
+            onRestoreDefault = {
+                BackgroundManager.provisionDefaultDashboardCardBg(context)
+                showToast(context, context.getString(R.string.dashboard_card_background_restored))
+            },
+            restoreLabel = stringResource(R.string.dashboard_card_background_restore)
         )
     }
 }
@@ -772,10 +777,12 @@ private fun ModeLabelChip(label: String, contentColor: Color) {
 private fun VersionInfoColumn(
     modifier: Modifier = Modifier,
     label: String,
-    value: String
+    value: String,
+    horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally
 ) {
     Column(
-        modifier = modifier
+        modifier = modifier,
+        horizontalAlignment = horizontalAlignment
     ) {
         Text(
             text = label,

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -188,6 +188,8 @@
     <string name="settings_selinux_current_mode">当前: %s</string>
     <string name="settings_selinux_mode_enforcing_summary">SELinux 完全强制执行访问规则</string>
     <string name="settings_selinux_mode_permissive_summary">SELinux 仅记录违规操作,不会拒绝</string>
+    <string name="msg_selinux_permissive_warning">切换为宽容模式将关闭SELinux强制拦截，权限违规行为仅记录日志而不会直接拒绝，设备安全性会下降，是否继续？</string>
+    <string name="msg_selinux_enforcing_confirm">切换为强制模式？SELinux将启用完整权限管控，拦截所有未授权访问行为。</string>
 
     <string name="home_device_info">设备</string>
     <string name="home_system_version">系统版本</string>
@@ -867,6 +869,8 @@ KernelPatch 需要修补 boot 镜像。
     <string name="dashboard_card_background_saved">仪表盘壁纸保存成功</string>
     <string name="dashboard_card_background_error">仪表盘壁纸保存失败</string>
     <string name="dashboard_card_background_cleared">仪表盘壁纸已清除</string>
+    <string name="dashboard_card_background_restore">恢复默认壁纸</string>
+    <string name="dashboard_card_background_restored">已恢复默认壁纸</string>
     <string name="settings_dashboard_card_dual_dim">启用昼夜双暗度</string>
     <string name="settings_dashboard_card_dual_dim_desc">自动根据明暗主题调整仪表盘壁纸暗度</string>
     <string name="settings_dashboard_card_day_dim">白天模式仪表盘壁纸暗度</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -948,6 +948,8 @@ Please ensure the app is completely closed and reopened for the commands to exec
     <string name="dashboard_card_background_saved">Dashboard wallpaper saved successfully</string>
     <string name="dashboard_card_background_error">Failed to save dashboard wallpaper</string>
     <string name="dashboard_card_background_cleared">Dashboard wallpaper cleared</string>
+    <string name="dashboard_card_background_restore">Restore Default</string>
+    <string name="dashboard_card_background_restored">Default wallpaper restored</string>
     <string name="settings_dashboard_card_dual_dim">Enable dual day/night dim</string>
     <string name="settings_dashboard_card_dual_dim_desc">Automatically adjust dashboard wallpaper dim for light and dark themes</string>
     <string name="settings_dashboard_card_day_dim">Day mode dashboard wallpaper dim</string>


### PR DESCRIPTION
添加仪表盘壁纸恢复默认功能按钮  在长按仪表盘弹出框
调整仪表盘ui布局  卡片信息对其方式
增加依赖的字符串