### PR TITLE
feat(theme): add uCrop-based background cropping

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -389,6 +389,7 @@ ksp {
 
 dependencies {
     implementation(libs.androidx.appcompat)
+    implementation(libs.ucrop)
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.webkit)

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -73,3 +73,8 @@
 -allowaccessmodification
 -overloadaggressively
 -renamesourcefileattribute SourceFile
+
+# uCrop (com.github.yalantis:ucrop)
+-dontwarn com.yalantis.ucrop**
+-keep class com.yalantis.ucrop** { *; }
+-keep interface com.yalantis.ucrop** { *; }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -149,6 +149,11 @@
             android:name=".ui.CrashHandleActivity"
             android:exported="false" />
 
+        <activity
+            android:name=".ui.screen.settings.crop.BackgroundCropActivity"
+            android:exported="false"
+            android:theme="@style/Theme.APatch" />
+
         <provider
             android:name=".util.SafeFileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/me/bmax/apatch/ui/component/KeyPointSlider.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/component/KeyPointSlider.kt
@@ -1,0 +1,417 @@
+package me.bmax.apatch.ui.component
+
+import androidx.annotation.IntRange
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.horizontalDrag
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.input.pointer.PointerInputChange
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.progressBarRangeInfo
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+
+@Composable
+fun KeyPointSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    valueRange: ClosedFloatingPointRange<Float> = 0f..1f,
+    @IntRange(from = 0) steps: Int = 0,
+    keyPoints: List<Float>? = null,
+    showKeyPoints: Boolean = keyPoints != null || steps > 0,
+    magnetThreshold: Float = 0.02f,
+    colors: KeyPointSliderColors = keyPointSliderColors(),
+    onValueChangeFinished: (() -> Unit)? = null,
+) {
+    require(steps >= 0) { "steps should be >= 0" }
+    require(valueRange.start < valueRange.endInclusive) {
+        "valueRange start should be less than endInclusive"
+    }
+    require(magnetThreshold >= 0f) { "magnetThreshold should be >= 0" }
+
+    val currentOnValueChange by rememberUpdatedState(onValueChange)
+    val currentOnValueChangeFinished by rememberUpdatedState(onValueChangeFinished)
+    val layoutDirection = LocalLayoutDirection.current
+    val density = LocalDensity.current
+    var isDragging by remember { mutableStateOf(false) }
+
+    val tickValues = remember(keyPoints, steps, valueRange) {
+        computeTickValues(
+            keyPoints = keyPoints,
+            steps = steps,
+            valueRange = valueRange
+        )
+    }
+    val shouldAlwaysSnapToTick = keyPoints == null && steps > 0
+
+    fun updateValueFromPosition(x: Float, width: Float): Float {
+        val rawValue = positionToValue(
+            x = x,
+            width = width,
+            valueRange = valueRange,
+            isRtl = layoutDirection == LayoutDirection.Rtl,
+            thumbWidthPx = with(density) { 4.dp.toPx() }
+        )
+
+        val snappedValue = rawValue.snapToNearestTick(
+            valueRange = valueRange,
+            ticks = tickValues,
+            magnetThreshold = magnetThreshold,
+            alwaysSnap = shouldAlwaysSnapToTick
+        )
+        currentOnValueChange(snappedValue)
+        return snappedValue
+    }
+
+    Canvas(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(48.dp)
+            .pointerInput(enabled, valueRange, tickValues, magnetThreshold, layoutDirection) {
+                if (!enabled) return@pointerInput
+
+                awaitEachGesture {
+                    val down = awaitFirstDown(requireUnconsumed = false)
+                    isDragging = true
+                    var latestValue = updateValueFromPosition(down.position.x, size.width.toFloat())
+
+                    horizontalDrag(down.id) { change: PointerInputChange ->
+                        latestValue =
+                            updateValueFromPosition(change.position.x, size.width.toFloat())
+                        if (change.positionChange() != Offset.Zero) {
+                            change.consume()
+                        }
+                    }
+
+                    isDragging = false
+                    val snappedValue = latestValue.snapToNearestTick(
+                        valueRange = valueRange,
+                        ticks = tickValues,
+                        magnetThreshold = magnetThreshold,
+                        alwaysSnap = shouldAlwaysSnapToTick
+                    )
+                    if (snappedValue != value) {
+                        currentOnValueChange(snappedValue)
+                    }
+                    currentOnValueChangeFinished?.invoke()
+                }
+            }
+            .semantics {
+                if (!enabled) disabled()
+                progressBarRangeInfo = ProgressBarRangeInfo(
+                    current = value.coerceIn(valueRange.start, valueRange.endInclusive),
+                    range = valueRange,
+                    steps = steps
+                )
+                setProgress { target ->
+                    val snappedValue = target.snapToNearestTick(
+                        valueRange = valueRange,
+                        ticks = tickValues,
+                        magnetThreshold = magnetThreshold,
+                        alwaysSnap = shouldAlwaysSnapToTick
+                    )
+                    if (snappedValue == value) {
+                        false
+                    } else {
+                        currentOnValueChange(snappedValue)
+                        currentOnValueChangeFinished?.invoke()
+                        true
+                    }
+                }
+            }
+    ) {
+        drawKeyPointSlider(
+            value = value,
+            valueRange = valueRange,
+            enabled = enabled,
+            isRtl = layoutDirection == LayoutDirection.Rtl,
+            isDragging = isDragging,
+            drawStopIndicator = keyPoints == null,
+            tickFractions = if (showKeyPoints) {
+                tickValues.map { it.calcFraction(valueRange.start, valueRange.endInclusive) }
+            } else {
+                emptyList()
+            },
+            colors = colors
+        )
+    }
+}
+
+@Composable
+fun keyPointSliderColors(): KeyPointSliderColors = KeyPointSliderColors(
+    thumbColor = MaterialTheme.colorScheme.primary,
+    activeTrackColor = MaterialTheme.colorScheme.primary,
+    activeTickColor = MaterialTheme.colorScheme.onPrimary,
+    inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant,
+    inactiveTickColor = MaterialTheme.colorScheme.primary,
+    disabledThumbColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+    disabledActiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
+    disabledActiveTickColor = MaterialTheme.colorScheme.surface,
+    disabledInactiveTrackColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.12f),
+    disabledInactiveTickColor = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+)
+
+@Immutable
+data class KeyPointSliderColors(
+    val thumbColor: Color,
+    val activeTrackColor: Color,
+    val activeTickColor: Color,
+    val inactiveTrackColor: Color,
+    val inactiveTickColor: Color,
+    val disabledThumbColor: Color,
+    val disabledActiveTrackColor: Color,
+    val disabledActiveTickColor: Color,
+    val disabledInactiveTrackColor: Color,
+    val disabledInactiveTickColor: Color,
+)
+
+private fun DrawScope.drawKeyPointSlider(
+    value: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    enabled: Boolean,
+    isRtl: Boolean,
+    isDragging: Boolean,
+    drawStopIndicator: Boolean,
+    tickFractions: List<Float>,
+    colors: KeyPointSliderColors,
+) {
+    val coercedValue = value.coerceIn(valueRange.start, valueRange.endInclusive)
+    val fraction = coercedValue.calcFraction(valueRange.start, valueRange.endInclusive)
+    val visualFraction = if (isRtl) 1f - fraction else fraction
+    val thumbWidth = 4.dp.toPx()
+    val thumbHeight = if (isDragging) 48.dp.toPx() else 44.dp.toPx()
+    val trackHeight = 16.dp.toPx()
+    val tickSize = 4.dp.toPx()
+    val stopIndicatorSize = 4.dp.toPx()
+    val trackCorner = trackHeight / 2f
+    val trackInsideCorner = 2.dp.toPx()
+    val thumbTrackGap = 6.dp.toPx()
+    val minX = thumbWidth / 2f
+    val maxX = (size.width - thumbWidth / 2f).coerceAtLeast(minX)
+    val centerY = size.height / 2f
+    val trackTop = centerY - trackHeight / 2f
+    val thumbX = minX + (maxX - minX) * visualFraction
+    val inactiveTrackColor = colors.trackColorCompat(enabled, active = false)
+    val activeTrackColor = colors.trackColorCompat(enabled, active = true)
+    val gapStart = (thumbX - thumbWidth / 2f - thumbTrackGap).coerceIn(minX, maxX)
+    val gapEnd = (thumbX + thumbWidth / 2f + thumbTrackGap).coerceIn(minX, maxX)
+
+    if (isRtl) {
+        drawTrackSegment(
+            color = activeTrackColor,
+            startX = gapEnd,
+            endX = maxX,
+            top = trackTop,
+            height = trackHeight,
+            startCorner = trackInsideCorner,
+            endCorner = trackCorner
+        )
+        drawTrackSegment(
+            color = inactiveTrackColor,
+            startX = minX,
+            endX = gapStart,
+            top = trackTop,
+            height = trackHeight,
+            startCorner = trackCorner,
+            endCorner = trackInsideCorner
+        )
+    } else {
+        drawTrackSegment(
+            color = activeTrackColor,
+            startX = minX,
+            endX = gapStart,
+            top = trackTop,
+            height = trackHeight,
+            startCorner = trackCorner,
+            endCorner = trackInsideCorner
+        )
+        drawTrackSegment(
+            color = inactiveTrackColor,
+            startX = gapEnd,
+            endX = maxX,
+            top = trackTop,
+            height = trackHeight,
+            startCorner = trackInsideCorner,
+            endCorner = trackCorner
+        )
+    }
+
+    val stopIndicatorX = if (isRtl) minX + trackCorner else maxX - trackCorner
+    if (drawStopIndicator) {
+        drawCircle(
+            color = activeTrackColor,
+            radius = stopIndicatorSize / 2f,
+            center = Offset(stopIndicatorX, centerY)
+        )
+    }
+
+    val tickGapStart = min(gapStart, gapEnd) - tickSize / 2f
+    val tickGapEnd = max(gapStart, gapEnd) + tickSize / 2f
+    tickFractions.forEach { tickFraction ->
+        val visualTickFraction = if (isRtl) 1f - tickFraction else tickFraction
+        val x = minX + (maxX - minX) * visualTickFraction
+
+        if (x in tickGapStart..tickGapEnd) return@forEach
+        if (drawStopIndicator && abs(x - stopIndicatorX) <= stopIndicatorSize) return@forEach
+
+        val active = tickFraction <= fraction
+        drawCircle(
+            color = colors.tickColorCompat(enabled, active),
+            radius = tickSize / 2f,
+            center = Offset(x, centerY)
+        )
+    }
+
+    drawRoundRect(
+        color = colors.thumbColorCompat(enabled),
+        topLeft = Offset(thumbX - thumbWidth / 2f, centerY - thumbHeight / 2f),
+        size = Size(thumbWidth, thumbHeight),
+        cornerRadius = CornerRadius(thumbWidth / 2f, thumbWidth / 2f)
+    )
+}
+
+private val trackPath = Path()
+
+private fun DrawScope.drawTrackSegment(
+    color: Color,
+    startX: Float,
+    endX: Float,
+    top: Float,
+    height: Float,
+    startCorner: Float,
+    endCorner: Float,
+) {
+    if (endX <= startX) return
+
+    val segmentWidth = endX - startX
+    val leftCorner = min(startCorner, segmentWidth / 2f)
+    val rightCorner = min(endCorner, segmentWidth / 2f)
+
+    trackPath.addRoundRect(
+        RoundRect(
+            rect = Rect(
+                offset = Offset(startX, top),
+                size = Size(segmentWidth, height)
+            ),
+            topLeft = CornerRadius(leftCorner, leftCorner),
+            bottomLeft = CornerRadius(leftCorner, leftCorner),
+            topRight = CornerRadius(rightCorner, rightCorner),
+            bottomRight = CornerRadius(rightCorner, rightCorner)
+        )
+    )
+    drawPath(trackPath, color)
+    trackPath.rewind()
+}
+
+private fun computeTickValues(
+    keyPoints: List<Float>?,
+    steps: Int,
+    valueRange: ClosedFloatingPointRange<Float>,
+): List<Float> {
+    val rawTicks = keyPoints ?: if (steps > 0) {
+        List(steps + 2) { index ->
+            lerp(valueRange.start, valueRange.endInclusive, index.toFloat() / (steps + 1))
+        }
+    } else {
+        emptyList()
+    }
+
+    return rawTicks
+        .map { it.coerceIn(valueRange.start, valueRange.endInclusive) }
+        .distinct()
+        .sorted()
+}
+
+private fun positionToValue(
+    x: Float,
+    width: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    isRtl: Boolean,
+    thumbWidthPx: Float,
+): Float {
+    val minX = thumbWidthPx / 2f
+    val maxX = max(width - thumbWidthPx / 2f, minX)
+    val visualFraction = ((x - minX) / (maxX - minX).coerceAtLeast(1f)).coerceIn(0f, 1f)
+    val fraction = if (isRtl) 1f - visualFraction else visualFraction
+
+    return lerp(valueRange.start, valueRange.endInclusive, fraction)
+}
+
+private fun Float.snapToNearestTick(
+    valueRange: ClosedFloatingPointRange<Float>,
+    ticks: List<Float>,
+    magnetThreshold: Float,
+    alwaysSnap: Boolean,
+): Float {
+    val coerced = coerceIn(valueRange.start, valueRange.endInclusive)
+    if (ticks.isEmpty()) return coerced
+
+    val rangeSize = valueRange.endInclusive - valueRange.start
+    val thresholdValue = rangeSize * magnetThreshold
+    val nearest = ticks.minByOrNull { abs(it - coerced) } ?: return coerced
+
+    return if (alwaysSnap || abs(nearest - coerced) <= thresholdValue) nearest else coerced
+}
+
+private fun Float.calcFraction(start: Float, end: Float): Float {
+    val range = end - start
+    if (range == 0f) return 0f
+    return ((this - start) / range).coerceIn(0f, 1f)
+}
+
+private fun lerp(start: Float, stop: Float, fraction: Float): Float {
+    return start + (stop - start) * fraction
+}
+
+private fun KeyPointSliderColors.thumbColorCompat(enabled: Boolean): Color {
+    return if (enabled) thumbColor else disabledThumbColor
+}
+
+private fun KeyPointSliderColors.trackColorCompat(enabled: Boolean, active: Boolean): Color {
+    return when {
+        enabled && active -> activeTrackColor
+        enabled -> inactiveTrackColor
+        active -> disabledActiveTrackColor
+        else -> disabledInactiveTrackColor
+    }
+}
+
+private fun KeyPointSliderColors.tickColorCompat(enabled: Boolean, active: Boolean): Color {
+    return when {
+        enabled && active -> activeTickColor
+        enabled -> inactiveTickColor
+        active -> disabledActiveTickColor
+        else -> disabledInactiveTickColor
+    }
+}

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/AppearanceSettings.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/AppearanceSettings.kt
@@ -6,7 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.provider.MediaStore
+import android.graphics.BitmapFactory
 import me.bmax.apatch.ui.component.ColorGenerationModeSelector
 import me.bmax.apatch.ui.component.SliderSettingCard
 import me.bmax.apatch.ui.component.SliderStyleConfig
@@ -15,13 +15,15 @@ import me.bmax.apatch.ui.component.ColorStylePicker
 import me.bmax.apatch.ui.theme.ColorGenerationMode
 import me.bmax.apatch.ui.theme.ColorStandard
 import me.bmax.apatch.ui.theme.ColorStyle
+import me.bmax.apatch.ui.screen.settings.crop.BackgroundCropActivity
 import me.bmax.apatch.util.ui.showToast
+import com.yalantis.ucrop.UCrop
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContract
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
 import java.io.File
 import androidx.annotation.StringRes
+import kotlin.math.max
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -91,7 +93,6 @@ import me.bmax.apatch.ui.screen.settings.appearance.colorNameToString
 import me.bmax.apatch.ui.screen.settings.appearance.homeLayoutStyleToString
 import me.bmax.apatch.util.PermissionUtils
 import me.bmax.apatch.util.BottomBarIconConfig
-import me.bmax.apatch.util.SafeUriResolver
 import me.bmax.apatch.util.ui.FloatingBarConfig
 import me.bmax.apatch.util.ui.APDialogBlurBehindUtils
 import me.bmax.apatch.util.ui.NavigationBarsSpacer
@@ -122,75 +123,57 @@ fun AppearanceSettingsContent(
     var pendingCropUri by remember { mutableStateOf<Uri?>(null) }
     var showCropOptionDialog by remember { mutableStateOf(false) }
 
-    // 裁剪 launcher：将选取的图片交给系统裁剪界面，返回裁剪后的 URI
-    val cropImageLauncher = rememberLauncherForActivityResult(
-        object : ActivityResultContract<Uri, Uri?>() {
-            override fun createIntent(context: Context, input: Uri): Intent {
-                val tempFile = File(context.cacheDir, "background_crop_cache").apply {
-                    parentFile?.mkdirs()
-                    delete()
-                    createNewFile()
-                    deleteOnExit()
-                }
-
-                SafeUriResolver.openInputStream(context, input).use { inputStream ->
-                    tempFile.outputStream().use { outputStream ->
-                        inputStream.copyTo(outputStream)
+    // uCrop launcher: start in-app crop activity
+    val uCropLauncher = rememberLauncherForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { result ->
+        val data = result.data
+        if (result.resultCode == Activity.RESULT_OK && data != null) {
+            val croppedUri = UCrop.getOutput(data)
+            if (croppedUri != null) {
+                scope.launch {
+                    loadingDialog.show()
+                    val success = when (pickingType) {
+                        "home" -> BackgroundManager.saveAndApplyHomeBackground(context, croppedUri)
+                        "kernel" -> BackgroundManager.saveAndApplyKernelBackground(context, croppedUri)
+                        "superuser" -> BackgroundManager.saveAndApplySuperuserBackground(context, croppedUri)
+                        "system" -> BackgroundManager.saveAndApplySystemModuleBackground(context, croppedUri)
+                        "settings" -> BackgroundManager.saveAndApplySettingsBackground(context, croppedUri)
+                        else -> BackgroundManager.saveAndApplyCustomBackground(context, croppedUri)
                     }
-                }
-
-                val tempUri = FileProvider.getUriForFile(
-                    context,
-                    "${context.packageName}.fileprovider",
-                    tempFile
-                )
-
-                return Intent("com.android.camera.action.CROP").apply {
-                    setDataAndType(tempUri, "image/*")
-                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-                    putExtra("crop", "true")
-
-                    val displayMetrics = context.resources.displayMetrics
-                    val screenWidth = displayMetrics.widthPixels
-                    val screenHeight = displayMetrics.heightPixels
-
-                    putExtra("aspectX", screenWidth)
-                    putExtra("aspectY", screenHeight)
-                    putExtra("outputX", screenWidth)
-                    putExtra("outputY", screenHeight)
-
-                    putExtra("return-data", false)
-                    putExtra(MediaStore.EXTRA_OUTPUT, tempUri)
+                    loadingDialog.hide()
+                    if (success) {
+                        snackBarHost.showSnackbar(message = context.getString(R.string.settings_custom_background_saved))
+                        refreshTheme.value = true
+                    } else {
+                        snackBarHost.showSnackbar(message = context.getString(R.string.settings_custom_background_error))
+                    }
+                    pickingType = null
                 }
             }
-
-            override fun parseResult(resultCode: Int, intent: Intent?): Uri? {
-                return if (resultCode == Activity.RESULT_OK) intent?.data else null
-            }
+        } else if (result.resultCode == UCrop.RESULT_ERROR) {
+            showToast(context, context.getString(R.string.background_crop_failed))
+            pickingType = null
         }
-    ) { uri: Uri? ->
-        uri?.let {
-            scope.launch {
-                loadingDialog.show()
-                val success = when (pickingType) {
-                    "home" -> BackgroundManager.saveAndApplyHomeBackground(context, it)
-                    "kernel" -> BackgroundManager.saveAndApplyKernelBackground(context, it)
-                    "superuser" -> BackgroundManager.saveAndApplySuperuserBackground(context, it)
-                    "system" -> BackgroundManager.saveAndApplySystemModuleBackground(context, it)
-                    "settings" -> BackgroundManager.saveAndApplySettingsBackground(context, it)
-                    else -> BackgroundManager.saveAndApplyCustomBackground(context, it)
-                }
-                loadingDialog.hide()
-                if (success) {
-                    snackBarHost.showSnackbar(message = context.getString(R.string.settings_custom_background_saved))
-                    refreshTheme.value = true
-                } else {
-                    snackBarHost.showSnackbar(message = context.getString(R.string.settings_custom_background_error))
-                }
-                pickingType = null
-            }
+    }
+
+    // Launch uCrop with screen aspect ratio and output capped at min(source, 4096)
+    fun launchUCrop(sourceUri: Uri) {
+        val outputUri = context.createBackgroundCropOutputUri("background_crop_ucrop")
+        val displayMetrics = context.resources.displayMetrics
+        val screenWidth = displayMetrics.widthPixels
+        val screenHeight = displayMetrics.heightPixels
+        val maxOutputSize = context.readImageMaxSide(sourceUri)?.coerceAtMost(MAX_CROP_OUTPUT_SIZE)
+            ?: max(screenWidth, screenHeight)
+        val intent = Intent(context, BackgroundCropActivity::class.java).apply {
+            putExtra(UCrop.EXTRA_INPUT_URI, sourceUri)
+            putExtra(UCrop.EXTRA_OUTPUT_URI, outputUri)
+            putExtra(UCrop.EXTRA_ASPECT_RATIO_X, screenWidth.toFloat())
+            putExtra(UCrop.EXTRA_ASPECT_RATIO_Y, screenHeight.toFloat())
+            putExtra(UCrop.EXTRA_MAX_SIZE_X, maxOutputSize)
+            putExtra(UCrop.EXTRA_MAX_SIZE_Y, maxOutputSize)
         }
+        uCropLauncher.launch(intent)
     }
 
     val pickImageLauncher = rememberLauncherForActivityResult(
@@ -218,25 +201,7 @@ fun AppearanceSettingsContent(
                     val uri = pendingCropUri!!
                     pendingCropUri = null
                     try {
-                        cropImageLauncher.launch(uri)
-                    } catch (e: ActivityNotFoundException) {
-                        showToast(context, context.getString(R.string.settings_crop_not_supported))
-                        scope.launch {
-                            loadingDialog.show()
-                            val success = when (pickingType) {
-                                "home" -> BackgroundManager.saveAndApplyHomeBackground(context, uri)
-                                "kernel" -> BackgroundManager.saveAndApplyKernelBackground(context, uri)
-                                "superuser" -> BackgroundManager.saveAndApplySuperuserBackground(context, uri)
-                                "system" -> BackgroundManager.saveAndApplySystemModuleBackground(context, uri)
-                                "settings" -> BackgroundManager.saveAndApplySettingsBackground(context, uri)
-                                else -> BackgroundManager.saveAndApplyCustomBackground(context, uri)
-                            }
-                            loadingDialog.hide()
-                            if (success) {
-                                refreshTheme.value = true
-                            }
-                            pickingType = null
-                        }
+                        launchUCrop(uri)
                     } catch (e: Exception) {
                         // 源图片 URI 已失效（如文件被删除/回收）时读取会抛 FileNotFoundException
                         showToast(context, context.getString(R.string.settings_custom_background_error))
@@ -2191,4 +2156,28 @@ fun AppearanceSettingsContent(
         )
     }
 }
+
+/** Max crop output size to prevent OOM (peak ~64MB) */
+private const val MAX_CROP_OUTPUT_SIZE = 4096
+
+private fun Context.createBackgroundCropOutputUri(prefix: String): Uri {
+    val outputFile = File(cacheDir, "${prefix}_${System.currentTimeMillis()}.jpg").apply {
+        parentFile?.mkdirs()
+        delete()
+        createNewFile()
+        deleteOnExit()
+    }
+    return FileProvider.getUriForFile(this, "${packageName}.fileprovider", outputFile)
+}
+
+/** Lightweight probe of image max side (inJustDecodeBounds, no pixel decode). */
+private fun Context.readImageMaxSide(uri: Uri): Int? = runCatching {
+    val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
+    contentResolver.openInputStream(uri)?.use { input ->
+        BitmapFactory.decodeStream(input, null, bounds)
+    }
+    val width = bounds.outWidth
+    val height = bounds.outHeight
+    if (width > 0 && height > 0) max(width, height) else null
+}.getOrNull()
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/crop/BackgroundCropActivity.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/crop/BackgroundCropActivity.kt
@@ -1,0 +1,698 @@
+package me.bmax.apatch.ui.screen.settings.crop
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.RectF
+import android.net.Uri
+import android.os.Bundle
+import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.add
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Check
+import androidx.compose.material.icons.twotone.Close
+import androidx.compose.material.icons.twotone.RestartAlt
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LargeFlexibleTopAppBar
+import androidx.compose.material3.LoadingIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.PlainTooltip
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipBox
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTooltipState
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.PopupPositionProvider
+import me.bmax.apatch.R
+import me.bmax.apatch.ui.component.KeyPointSlider
+import me.bmax.apatch.ui.theme.APatchTheme
+import com.yalantis.ucrop.UCrop
+import com.yalantis.ucrop.callback.BitmapCropCallback
+import com.yalantis.ucrop.view.OverlayView
+import com.yalantis.ucrop.view.TransformImageView
+import com.yalantis.ucrop.view.UCropView
+import java.io.Serializable
+import kotlin.math.max
+import kotlin.math.min
+
+class BackgroundCropActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+
+        val inputUri = intent.getParcelableExtraCompat<Uri>(UCrop.EXTRA_INPUT_URI)
+        val outputUri = intent.getParcelableExtraCompat<Uri>(UCrop.EXTRA_OUTPUT_URI)
+        val aspectRatioX = intent.getFloatExtra(UCrop.EXTRA_ASPECT_RATIO_X, 0f)
+        val aspectRatioY = intent.getFloatExtra(UCrop.EXTRA_ASPECT_RATIO_Y, 0f)
+        val maxSizeX = intent.getIntExtra(UCrop.EXTRA_MAX_SIZE_X, 0)
+        val maxSizeY = intent.getIntExtra(UCrop.EXTRA_MAX_SIZE_Y, 0)
+
+        if (inputUri == null || outputUri == null) {
+            finishWithError(IllegalArgumentException("Crop input or output Uri is missing."))
+            return
+        }
+
+        val sourceImageAspectRatio = resolveImageAspectRatio(inputUri)
+
+        setContent {
+            APatchTheme {
+                BackgroundCropScreen(
+                    inputUri = inputUri,
+                    outputUri = outputUri,
+                    aspectRatioX = aspectRatioX,
+                    aspectRatioY = aspectRatioY,
+                    sourceImageAspectRatio = sourceImageAspectRatio,
+                    maxSizeX = maxSizeX,
+                    maxSizeY = maxSizeY,
+                    onCancel = {
+                        setResult(RESULT_CANCELED)
+                        finish()
+                    },
+                    onCropped = { uri, width, height, offsetX, offsetY ->
+                        finishWithResult(uri, width, height, offsetX, offsetY)
+                    },
+                    onError = ::finishWithError
+                )
+            }
+        }
+    }
+
+    private fun finishWithResult(
+        uri: Uri,
+        width: Int,
+        height: Int,
+        offsetX: Int,
+        offsetY: Int
+    ) {
+        val result = Intent()
+            .putExtra(UCrop.EXTRA_OUTPUT_URI, uri)
+            .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_WIDTH, width)
+            .putExtra(UCrop.EXTRA_OUTPUT_IMAGE_HEIGHT, height)
+            .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_X, offsetX)
+            .putExtra(UCrop.EXTRA_OUTPUT_OFFSET_Y, offsetY)
+        setResult(RESULT_OK, result)
+        finish()
+    }
+
+    private fun finishWithError(error: Throwable) {
+        val result = Intent().putExtra(UCrop.EXTRA_ERROR, error as Serializable)
+        setResult(UCrop.RESULT_ERROR, result)
+        finish()
+    }
+
+    private fun resolveImageAspectRatio(uri: Uri): Float? {
+        val options = BitmapFactory.Options().apply {
+            inJustDecodeBounds = true
+        }
+        return runCatching {
+            contentResolver.openInputStream(uri)?.use { inputStream ->
+                BitmapFactory.decodeStream(inputStream, null, options)
+            }
+            val width = options.outWidth
+            val height = options.outHeight
+            if (width > 0 && height > 0) {
+                width.toFloat() / height.toFloat()
+            } else {
+                null
+            }
+        }.getOrNull()
+    }
+}
+
+@SuppressLint("AutoboxingStateCreation")
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+private fun BackgroundCropScreen(
+    inputUri: Uri,
+    outputUri: Uri,
+    aspectRatioX: Float,
+    aspectRatioY: Float,
+    sourceImageAspectRatio: Float?,
+    maxSizeX: Int,
+    maxSizeY: Int,
+    onCancel: () -> Unit,
+    onCropped: (Uri, Int, Int, Int, Int) -> Unit,
+    onError: (Throwable) -> Unit
+) {
+    val context = LocalContext.current
+    var cropView by remember { mutableStateOf<UCropView?>(null) }
+    var isLoading by remember { mutableStateOf(true) }
+    var isCropping by remember { mutableStateOf(false) }
+    var loadFailed by remember { mutableStateOf(false) }
+    var rotationAngle by remember { mutableFloatStateOf(0f) }
+    var cropViewReloadToken by remember { mutableIntStateOf(0) }
+    val topAppBarState = rememberTopAppBarState()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
+
+    val primaryColor = MaterialTheme.colorScheme.primary.toArgb()
+    val onSurfaceColor = MaterialTheme.colorScheme.onSurface.toArgb()
+    val scrimColor = MaterialTheme.colorScheme.scrim.copy(alpha = 0.58f).toArgb()
+
+    fun syncCropControls() {
+        cropView?.cropImageView?.let { imageView ->
+            rotationAngle = imageView.currentAngle.normalizedCropAngle()
+        }
+    }
+
+    fun updateRotation(targetAngle: Float) {
+        cropView?.cropImageView?.let { imageView ->
+            val normalizedTarget = targetAngle.normalizedCropAngle()
+            val delta = (normalizedTarget - imageView.currentAngle.normalizedCropAngle())
+                .normalizedCropAngle()
+            imageView.cancelAllAnimations()
+            imageView.postRotate(delta)
+            rotationAngle = normalizedTarget
+        }
+    }
+
+    fun finishRotationAdjustment() {
+        cropView?.cropImageView?.setImageToWrapCropBounds()
+    }
+
+    SideEffect {
+        topAppBarState.heightOffset = topAppBarState.heightOffsetLimit
+        topAppBarState.contentOffset = 0f
+    }
+
+    fun cropCurrentImage() {
+        val imageView = cropView?.cropImageView ?: return
+        isCropping = true
+        imageView.setImageToWrapCropBounds()
+        imageView.cropAndSaveImage(
+            Bitmap.CompressFormat.JPEG,
+            100,
+            object : BitmapCropCallback {
+                override fun onBitmapCropped(
+                    resultUri: Uri,
+                    offsetX: Int,
+                    offsetY: Int,
+                    imageWidth: Int,
+                    imageHeight: Int
+                ) {
+                    (context as Activity).runOnUiThread {
+                        isCropping = false
+                        onCropped(resultUri, imageWidth, imageHeight, offsetX, offsetY)
+                    }
+                }
+
+                override fun onCropFailure(t: Throwable) {
+                    (context as Activity).runOnUiThread {
+                        isCropping = false
+                        onError(t)
+                    }
+                }
+            }
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            LargeFlexibleTopAppBar(
+                title = { Text(stringResource(R.string.background_crop_title)) },
+                navigationIcon = {
+                    CropTooltipIconButton(
+                        tooltip = stringResource(R.string.cancel),
+                        enabled = !isCropping,
+                        onClick = onCancel
+                    ) {
+                        Icon(
+                            Icons.TwoTone.Close,
+                            contentDescription = stringResource(R.string.cancel)
+                        )
+                    }
+                },
+                actions = {
+                    CropTooltipIconButton(
+                        tooltip = stringResource(R.string.background_crop_reset),
+                        onClick = {
+                            cropView = null
+                            isLoading = true
+                            loadFailed = false
+                            rotationAngle = 0f
+                            cropViewReloadToken++
+                        },
+                        enabled = !isLoading && !isCropping && !loadFailed
+                    ) {
+                        Icon(
+                            Icons.TwoTone.RestartAlt,
+                            contentDescription = stringResource(R.string.background_crop_reset)
+                        )
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surfaceContainer,
+                    scrolledContainerColor = MaterialTheme.colorScheme.surfaceContainer
+                ),
+                windowInsets = TopAppBarDefaults.windowInsets.add(WindowInsets(left = 12.dp)),
+                scrollBehavior = scrollBehavior
+            )
+        },
+        bottomBar = {
+            Surface(
+                modifier = Modifier.wrapContentHeight(),
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                tonalElevation = 3.dp
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .wrapContentHeight()
+                        .navigationBarsPadding()
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = stringResource(R.string.background_crop_rotation_angle),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.width(84.dp)
+                        )
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .height(48.dp)
+                        ) {
+                            KeyPointSlider(
+                                value = rotationAngle.coerceIn(-180f, 180f),
+                                onValueChange = ::updateRotation,
+                                valueRange = -180f..180f,
+                                keyPoints = listOf(-90f, 0f, 90f),
+                                enabled = !isLoading && !isCropping && !loadFailed,
+                                onValueChangeFinished = ::finishRotationAdjustment,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
+                        Text(
+                            text = "${rotationAngle.toInt()}\u00B0",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .width(48.dp)
+                                .padding(start = 8.dp)
+                        )
+                    }
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Button(
+                            onClick = ::cropCurrentImage,
+                            enabled = !isLoading && !isCropping && !loadFailed
+                        ) {
+                            Icon(
+                                imageVector = Icons.TwoTone.Check,
+                                contentDescription = null
+                            )
+                            Text(
+                                text = stringResource(R.string.background_crop_apply),
+                                modifier = Modifier.padding(start = 8.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            key(cropViewReloadToken) {
+                AndroidView(
+                    modifier = Modifier.fillMaxSize(),
+                    factory = { viewContext ->
+                        UCropView(viewContext, null).apply {
+                            layoutParams = FrameLayout.LayoutParams(
+                                FrameLayout.LayoutParams.MATCH_PARENT,
+                                FrameLayout.LayoutParams.MATCH_PARENT
+                            )
+                            cropImageView.isScaleEnabled = true
+                            cropImageView.isRotateEnabled = false
+                            cropImageView.isGestureEnabled = true
+                            cropImageView.doubleTapScaleSteps = 5
+                            cropImageView.setMaxScaleMultiplier(10f)
+                            val cropAspectRatio = if (aspectRatioX > 0f && aspectRatioY > 0f) {
+                                aspectRatioX / aspectRatioY
+                            } else {
+                                null
+                            }
+                            if (aspectRatioX > 0f && aspectRatioY > 0f) {
+                                cropAspectRatio?.let {
+                                    cropImageView.setTargetAspectRatio(it)
+                                    overlayView.setTargetAspectRatio(it)
+                                }
+                            }
+                            if (maxSizeX > 0) cropImageView.setMaxResultImageSizeX(maxSizeX)
+                            if (maxSizeY > 0) cropImageView.setMaxResultImageSizeY(maxSizeY)
+                            overlayView.setShowCropFrame(true)
+                            overlayView.setShowCropGrid(true)
+                            overlayView.setFreestyleCropMode(OverlayView.FREESTYLE_CROP_MODE_ENABLE)
+                            cropAspectRatio?.let(overlayView::setAspectLockedCornerResize)
+                            overlayView.setCropFrameColor(primaryColor)
+                            overlayView.setCropGridColor(onSurfaceColor)
+                            overlayView.setDimmedColor(scrimColor)
+                            cropImageView.setTransformImageListener(
+                                object : TransformImageView.TransformImageListener {
+                                    override fun onLoadComplete() {
+                                        isLoading = false
+                                        loadFailed = false
+                                        syncCropControls()
+                                    }
+
+                                    override fun onLoadFailure(e: Exception) {
+                                        isLoading = false
+                                        loadFailed = true
+                                        onError(e)
+                                    }
+
+                                    override fun onRotate(currentAngle: Float) {
+                                        rotationAngle = currentAngle.normalizedCropAngle()
+                                    }
+
+                                    override fun onScale(currentScale: Float) = Unit
+                                }
+                            )
+                            cropView = this
+                            runCatching {
+                                cropImageView.setImageUri(inputUri, outputUri)
+                            }.onFailure {
+                                visibility = View.INVISIBLE
+                                isLoading = false
+                                loadFailed = true
+                                onError(it)
+                            }
+                        }
+                    },
+                    update = {
+                        it.visibility =
+                            if (isLoading || loadFailed) View.INVISIBLE else View.VISIBLE
+                        it.overlayView.setCropFrameColor(primaryColor)
+                        it.overlayView.setCropGridColor(onSurfaceColor)
+                        it.overlayView.setDimmedColor(scrimColor)
+                    }
+                )
+            }
+
+            if (isLoading || isCropping) {
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    LoadingIndicator()
+                    Text(
+                        text = stringResource(R.string.background_crop_loading),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 16.dp)
+                    )
+                }
+            }
+        }
+    }
+
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Suppress("DEPRECATION")
+@Composable
+private fun CropTooltipIconButton(
+    tooltip: String,
+    enabled: Boolean,
+    onClick: () -> Unit,
+    icon: @Composable () -> Unit
+) {
+    TooltipBox(
+        positionProvider = remember { BelowAnchorTooltipPositionProvider() },
+        tooltip = {
+            PlainTooltip {
+                Text(tooltip)
+            }
+        },
+        state = rememberTooltipState()
+    ) {
+        IconButton(
+            onClick = onClick,
+            enabled = enabled
+        ) {
+            icon()
+        }
+    }
+}
+
+@SuppressLint("ClickableViewAccessibility")
+private fun OverlayView.setAspectLockedCornerResize(aspectRatio: Float) {
+    if (!aspectRatio.isFinite() || aspectRatio <= 0f) {
+        return
+    }
+
+    val touchThreshold = 48f * resources.displayMetrics.density
+    val minCropSize = resources
+        .getDimensionPixelSize(com.yalantis.ucrop.R.dimen.ucrop_default_crop_rect_min_size)
+        .toFloat()
+    var activeCornerIndex = -1
+
+    setOnTouchListener { view, event ->
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                activeCornerIndex = cropViewRect.findTouchedCropCorner(
+                    touchX = event.x,
+                    touchY = event.y,
+                    threshold = touchThreshold
+                )
+                if (activeCornerIndex != -1) {
+                    view.onTouchEvent(event)
+                } else {
+                    false
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (activeCornerIndex == -1 || event.pointerCount != 1) {
+                    false
+                } else {
+                    val lockedPoint = cropViewRect.aspectLockedCornerPoint(
+                        cornerIndex = activeCornerIndex,
+                        touchX = event.x,
+                        touchY = event.y,
+                        aspectRatio = aspectRatio,
+                        minX = paddingLeft.toFloat(),
+                        minY = paddingTop.toFloat(),
+                        maxX = (width - paddingRight).toFloat(),
+                        maxY = (height - paddingBottom).toFloat(),
+                        minCropSize = minCropSize
+                    )
+                    val adjustedEvent = event.copyWithLocation(lockedPoint.x, lockedPoint.y)
+                    try {
+                        view.onTouchEvent(adjustedEvent)
+                    } finally {
+                        adjustedEvent.recycle()
+                    }
+                }
+            }
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                val handled = if (activeCornerIndex != -1) {
+                    view.onTouchEvent(event)
+                } else {
+                    false
+                }
+                activeCornerIndex = -1
+                handled
+            }
+
+            else -> false
+        }
+    }
+}
+
+private fun RectF.findTouchedCropCorner(
+    touchX: Float,
+    touchY: Float,
+    threshold: Float
+): Int {
+    val thresholdSquared = threshold * threshold
+    val corners = floatArrayOf(
+        left, top,
+        right, top,
+        right, bottom,
+        left, bottom
+    )
+
+    var closestCornerIndex = -1
+    var closestDistance = thresholdSquared
+    for (index in corners.indices step 2) {
+        val deltaX = touchX - corners[index]
+        val deltaY = touchY - corners[index + 1]
+        val distance = deltaX * deltaX + deltaY * deltaY
+        if (distance <= closestDistance) {
+            closestDistance = distance
+            closestCornerIndex = index / 2
+        }
+    }
+    return closestCornerIndex
+}
+
+private fun RectF.aspectLockedCornerPoint(
+    cornerIndex: Int,
+    touchX: Float,
+    touchY: Float,
+    aspectRatio: Float,
+    minX: Float,
+    minY: Float,
+    maxX: Float,
+    maxY: Float,
+    minCropSize: Float
+): CropTouchPoint {
+    val anchorX: Float
+    val anchorY: Float
+    val directionX: Float
+    val directionY: Float
+    when (cornerIndex) {
+        0 -> {
+            anchorX = right
+            anchorY = bottom
+            directionX = -1f
+            directionY = -1f
+        }
+
+        1 -> {
+            anchorX = left
+            anchorY = bottom
+            directionX = 1f
+            directionY = -1f
+        }
+
+        2 -> {
+            anchorX = left
+            anchorY = top
+            directionX = 1f
+            directionY = 1f
+        }
+
+        else -> {
+            anchorX = right
+            anchorY = top
+            directionX = -1f
+            directionY = 1f
+        }
+    }
+
+    val projectedDistance = (
+            (touchX - anchorX) * directionX * aspectRatio +
+                    (touchY - anchorY) * directionY
+            ) / (aspectRatio * aspectRatio + 1f)
+    val maxWidth = if (directionX > 0f) maxX - anchorX else anchorX - minX
+    val maxHeight = if (directionY > 0f) maxY - anchorY else anchorY - minY
+    val maxDistance = min(maxWidth / aspectRatio, maxHeight).coerceAtLeast(0f)
+    val minDistance = max(minCropSize / aspectRatio, minCropSize)
+    val safeDistance = if (maxDistance <= minDistance) {
+        maxDistance
+    } else {
+        projectedDistance.coerceIn(minDistance, maxDistance)
+    }
+
+    return CropTouchPoint(
+        x = anchorX + directionX * aspectRatio * safeDistance,
+        y = anchorY + directionY * safeDistance
+    )
+}
+
+private fun MotionEvent.copyWithLocation(x: Float, y: Float): MotionEvent =
+    MotionEvent.obtain(this).apply {
+        setLocation(x, y)
+    }
+
+private data class CropTouchPoint(
+    val x: Float,
+    val y: Float
+)
+
+private class BelowAnchorTooltipPositionProvider : PopupPositionProvider {
+    override fun calculatePosition(
+        anchorBounds: IntRect,
+        windowSize: IntSize,
+        layoutDirection: LayoutDirection,
+        popupContentSize: IntSize
+    ): IntOffset {
+        val centeredX = anchorBounds.left + (anchorBounds.width - popupContentSize.width) / 2
+        val x = centeredX.coerceIn(0, windowSize.width - popupContentSize.width)
+        val preferredY = anchorBounds.bottom + 8
+        val fallbackY = anchorBounds.top - popupContentSize.height - 8
+        val y = if (preferredY + popupContentSize.height <= windowSize.height) {
+            preferredY
+        } else {
+            fallbackY.coerceAtLeast(0)
+        }
+        return IntOffset(x, y)
+    }
+}
+
+private inline fun <reified T> Intent.getParcelableExtraCompat(name: String): T? =
+    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+        getParcelableExtra(name, T::class.java)
+    } else {
+        @Suppress("DEPRECATION")
+        getParcelableExtra(name)
+    }
+
+private fun Float.normalizedCropAngle(): Float {
+    var angle = this % 360f
+    if (angle > 180) angle -= 360f
+    if (angle < -180) angle += 360f
+    return angle
+}
+

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -1331,4 +1331,10 @@ KernelPatch 需要修补 boot 镜像。
     <string name="settings_info_copy">长按复制信息</string>
     <string name="settings_info_copy_summary">长按首页信息栏中的条目即可复制其内容</string>
     <string name="home_info_copied">%1$s 已复制</string>
+    <string name="background_crop_title">裁剪背景</string>
+    <string name="background_crop_apply">应用</string>
+    <string name="background_crop_reset">重置</string>
+    <string name="background_crop_loading">正在加载图片</string>
+    <string name="background_crop_rotation_angle">旋转</string>
+    <string name="background_crop_failed">裁剪图片失败</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1382,4 +1382,10 @@ Please ensure the app is completely closed and reopened for the commands to exec
     <string name="color_style_monochrome">Monochrome</string>
     <string name="color_style_neutral">Neutral</string>
     <string name="color_style_fidelity">Fidelity</string>
+    <string name="background_crop_title">Crop background</string>
+    <string name="background_crop_apply">Apply</string>
+    <string name="background_crop_reset">Reset</string>
+    <string name="background_crop_loading">Loading image</string>
+    <string name="background_crop_rotation_angle">Rotation</string>
+    <string name="background_crop_failed">Failed to crop image</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ vico = "2.0.0-alpha.13"
 liquid = "1.1.1"
 material3 = "1.5.0-alpha17"
 materialKolor = "4.1.1"
+ucrop = "2.2.11"
 
 [plugins]
 agp-app = { id = "com.android.application", version.ref = "agp" }
@@ -80,3 +81,5 @@ cxx = { module = "org.lsposed.libcxx:libcxx", version = "29.0.14206865" }
 liquid = { group = "io.github.fletchmckee.liquid", name = "liquid-android", version.ref = "liquid" }
 
 materialKolor = { group = "com.materialkolor", name = "material-kolor", version.ref = "materialKolor" }
+
+ucrop = { module = "com.github.yalantis:ucrop", version.ref = "ucrop" }


### PR DESCRIPTION
Port uCrop-based in-app wallpaper cropping from ReSukiSU, replacing the system CROP intent that doesn't work on Android 10+.

- New uCrop crop activity (free-form crop + rotation slider)
- Aspect-locked corner resize, screen-ratio initial frame
- Output capped at 4096px / JPEG 100 to keep quality without OOM