### PR TITLE
Fix new app profile toggle state reset

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/GeneralSettings.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/GeneralSettings.kt
@@ -381,7 +381,7 @@ fun GeneralSettingsContent(
         item(key = "general_new_app_profile_enabled", visible = kPatchReady) {
             ToggleSettingCard(
                 flat = flat,
-                icon = Icons.Filled.Block,
+                icon = Icons.Filled.AppRegistration,
                 title = newAppProfileEnabledTitle,
                 description = newAppProfileEnabledSummary,
                 checked = newAppProfileEnabled,
@@ -418,7 +418,7 @@ fun GeneralSettingsContent(
                     modifier = Modifier.fillMaxWidth().padding(16.dp),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Icon(imageVector = Icons.Filled.Block, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(24.dp))
+                    Icon(imageVector = Icons.Filled.SettingsApplications, contentDescription = null, tint = MaterialTheme.colorScheme.onSurfaceVariant, modifier = Modifier.size(24.dp))
                     Spacer(Modifier.width(16.dp))
                     Column {
                         Text(

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/GeneralSettings.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/GeneralSettings.kt
@@ -402,6 +402,7 @@ fun GeneralSettingsContent(
                     } else {
                         runCatching { Natives.setNewAppProfileMode(0) }
                         newAppProfileMode = 0
+                        newAppProfileEnabled = false
                         prefs.edit {
                             putBoolean(APApplication.PREF_NEW_APP_PROFILE_ENABLED, false)
                             putInt(APApplication.PREF_AUTO_EXCLUDE_NEW_APPS, 0)

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -591,9 +591,9 @@ KernelPatch 需要修补 boot 镜像。
     <string name="dpi_confirm_message">将应用 DPI 从 %1$s 更改为 %2$s？</string>
     <string name="settings_magic_mount">Folk Mount API</string>
     <string name="settings_magic_mount_summary">启用内置的模块挂载系统</string>
-    <string name="settings_new_app_profile_enabled">新软件默认模式</string>
-    <string name="settings_new_app_profile_enabled_summary">开启后，新安装的软件会根据下方选择的模式自动配置</string>
-    <string name="settings_new_app_profile_mode">新软件默认模式</string>
+    <string name="settings_new_app_profile_enabled">新装应用自动授权</string>
+    <string name="settings_new_app_profile_enabled_summary">开启后，新安装的应用自动套用下方预设的授权模式</string>
+    <string name="settings_new_app_profile_mode">默认授权模式</string>
     <string name="settings_new_app_profile_normal">常规</string>
     <string name="settings_new_app_profile_root">超级用户</string>
     <string name="settings_new_app_profile_exclude">排除</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -600,9 +600,9 @@ KernelPatch 需要修補 boot 映像檔。
     <string name="dpi_confirm_message">將應用程式 DPI 從 %1$s 變更為 %2$s？</string>
     <string name="settings_magic_mount">Folk Mount API</string>
     <string name="settings_magic_mount_summary">啟用內建的模組掛載系統</string>
-    <string name="settings_new_app_profile_enabled">新軟體預設模式</string>
-    <string name="settings_new_app_profile_enabled_summary">開啟後，新安裝的軟體會根據下方選擇的模式自動配置</string>
-    <string name="settings_new_app_profile_mode">新軟體預設模式</string>
+    <string name="settings_new_app_profile_enabled">新裝應用自動授權</string>
+    <string name="settings_new_app_profile_enabled_summary">開啟後，新安裝的應用自動套用下方預設的授權模式</string>
+    <string name="settings_new_app_profile_mode">預設授權模式</string>
     <string name="settings_new_app_profile_normal">一般</string>
     <string name="settings_new_app_profile_root">超級使用者</string>
     <string name="settings_new_app_profile_exclude">排除</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -614,9 +614,9 @@ Here are some possible reasons for authentication failure—please check which o
     <string name="dpi_confirm_message">Change app DPI from %1$s to %2$s?</string>
     <string name="settings_magic_mount">Folk Mount API</string>
     <string name="settings_magic_mount_summary">Enable the built-in module mounting system</string>
-    <string name="settings_new_app_profile_enabled">New App Default Mode</string>
-    <string name="settings_new_app_profile_enabled_summary">Auto-configure default profile for newly installed apps</string>
-    <string name="settings_new_app_profile_mode">Default mode for new apps</string>
+    <string name="settings_new_app_profile_enabled">Auto-authorize New Apps</string>
+    <string name="settings_new_app_profile_enabled_summary">Apply preset authorization mode to new apps automatically</string>
+    <string name="settings_new_app_profile_mode">Default Authorization Mode</string>
     <string name="settings_new_app_profile_normal">NO ROOT</string>
     <string name="settings_new_app_profile_root">ROOT</string>
     <string name="settings_new_app_profile_exclude">Exclude</string>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,7 +34,7 @@ fun getGitDescribe(): String {
 }
 
 fun getVersionCode(): Int {
-    return 115008
+    return 115009
 }
 
 fun getbranch(): String {


### PR DESCRIPTION
Ensure that disabling the new app profile mode also sets `newAppProfileEnabled` to false, keeping the UI state consistent with preferences.