### PR TITLE
Remove pinned scrollBehavior and add back handler

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/MainActivity.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/MainActivity.kt
@@ -700,7 +700,7 @@ class MainActivity : AppCompatActivity() {
 
                 val currentBackStackEntry by navController.currentBackStackEntryAsState()
                 val currentRoute = currentBackStackEntry?.destination?.route
-
+                val homeRoute = bottomBarRoutes.first()
 
                 // Show bottom bar logic: hide when scrolling down in floating mode,
                 // plus 3s auto-hide after last interaction.
@@ -807,6 +807,13 @@ class MainActivity : AppCompatActivity() {
                                     LocalBottomBarVisible provides bottomBarVisibleState,
                                     LocalIsFloatingNavMode provides isFloatingMode
                                 ) {
+                                    BackHandler(enabled = currentRoute in bottomBarRoutes && currentRoute != homeRoute) {
+                                        navController.navigate(homeRoute) {
+                                            popUpTo(NavGraphs.root.route) { saveState = true }
+                                            launchSingleTop = true
+                                            restoreState = true
+                                        }
+                                    }
                                     DestinationsNavHost(
                                         modifier = Modifier.weight(1f).then(baseContentModifier),
                                         navGraph = NavGraphs.root,
@@ -842,7 +849,6 @@ class MainActivity : AppCompatActivity() {
                                 // Back press on a non-home tab returns to the home tab
                                 // with the floating bar reset; back on the home tab keeps
                                 // the system default (predictive back) behavior
-                                val homeRoute = bottomBarRoutes.first()
                                 BackHandler(enabled = currentRoute in bottomBarRoutes && currentRoute != homeRoute) {
                                     resetBottomBarFully()
                                     navController.navigate(homeRoute) {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Settings.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Settings.kt
@@ -105,7 +105,6 @@ fun SettingScreen(navigator: DestinationsNavigator) {
         showDevDialog = false
     }
 
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -127,8 +126,7 @@ fun SettingScreen(navigator: DestinationsNavigator) {
                     IconButton(onClick = { showDevDialog = true }) {
                         Icon(Icons.Outlined.Info, contentDescription = stringResource(R.string.about))
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
@@ -137,7 +135,6 @@ fun SettingScreen(navigator: DestinationsNavigator) {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
-                .nestedScroll(scrollBehavior.nestedScrollConnection),
         ) {
             item { Spacer(Modifier.height(8.dp)) }
 

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/AppearanceSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/AppearanceSettingsScreen.kt
@@ -49,7 +49,6 @@ fun AppearanceSettingsScreen(navigator: DestinationsNavigator, highlightKey: Str
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
     val prefs = APApplication.sharedPreferences
 
     val themeModeKey = "theme_mode"
@@ -63,15 +62,14 @@ fun AppearanceSettingsScreen(navigator: DestinationsNavigator, highlightKey: Str
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/BackupSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/BackupSettingsScreen.kt
@@ -45,7 +45,6 @@ fun BackupSettingsScreen(navigator: DestinationsNavigator, highlightKey: String?
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -55,15 +54,14 @@ fun BackupSettingsScreen(navigator: DestinationsNavigator, highlightKey: String?
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/BehaviorSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/BehaviorSettingsScreen.kt
@@ -44,8 +44,6 @@ fun BehaviorSettingsScreen(navigator: DestinationsNavigator, highlightKey: Strin
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
-
     Scaffold(
         topBar = {
             TopAppBar(
@@ -54,15 +52,14 @@ fun BehaviorSettingsScreen(navigator: DestinationsNavigator, highlightKey: Strin
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/FunctionSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/FunctionSettingsScreen.kt
@@ -225,7 +225,6 @@ fun FunctionSettingsScreen(navigator: DestinationsNavigator, highlightKey: Strin
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -235,15 +234,14 @@ fun FunctionSettingsScreen(navigator: DestinationsNavigator, highlightKey: Strin
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/GeneralSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/GeneralSettingsScreen.kt
@@ -67,7 +67,6 @@ fun GeneralSettingsScreen(navigator: DestinationsNavigator, highlightKey: String
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -77,15 +76,14 @@ fun GeneralSettingsScreen(navigator: DestinationsNavigator, highlightKey: String
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/ModuleSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/ModuleSettingsScreen.kt
@@ -44,7 +44,6 @@ fun ModuleSettingsScreen(navigator: DestinationsNavigator, highlightKey: String?
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -54,15 +53,14 @@ fun ModuleSettingsScreen(navigator: DestinationsNavigator, highlightKey: String?
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = "Back")
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/MultimediaSettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/MultimediaSettingsScreen.kt
@@ -37,7 +37,6 @@ import me.bmax.apatch.util.ui.NavigationBarsSpacer
 fun MultimediaSettingsScreen(navigator: DestinationsNavigator, highlightKey: String? = null) {
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -47,15 +46,14 @@ fun MultimediaSettingsScreen(navigator: DestinationsNavigator, highlightKey: Str
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/SecuritySettingsScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/SecuritySettingsScreen.kt
@@ -43,7 +43,6 @@ fun SecuritySettingsScreen(navigator: DestinationsNavigator, highlightKey: Strin
 
     val snackBarHost = LocalSnackbarHost.current
     val flat = BackgroundConfig.isCustomBackgroundEnabled || BackgroundConfig.settingsBackgroundUri != null
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     Scaffold(
         topBar = {
@@ -53,15 +52,14 @@ fun SecuritySettingsScreen(navigator: DestinationsNavigator, highlightKey: Strin
                     IconButton(onClick = { navigator.popBackStack() }) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
                     }
-                },
-                scrollBehavior = scrollBehavior,
+                }
             )
         },
         containerColor = Color.Transparent,
         snackbarHost = { SnackbarHost(snackBarHost) },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier.padding(paddingValues).nestedScroll(scrollBehavior.nestedScrollConnection),
+            modifier = Modifier.padding(paddingValues),
             verticalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             item {


### PR DESCRIPTION
Remove TopAppBarDefaults.pinnedScrollBehavior and related nestedScroll usage from multiple settings screens (Appearance, Backup, Behavior, Function, General, Module, Multimedia, Security) to simplify top app bar / list interaction. In MainActivity hoist homeRoute and add a BackHandler that navigates to the home tab (popUpTo root with save/restore state); update the existing back-handler to use the hoisted homeRoute. These changes simplify scroll behavior and improve back-navigation handling between bottom-bar tabs.
此修改 修复侧边栏 返回主页逻辑
            修复设置页面及二级页面上画 顶部有阴影块bug