### PR TITLE
Fix the bug where the font is black and unreadable in dark mode on the plugin page.

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/Plugin.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Plugin.kt
@@ -539,6 +539,7 @@ private fun EmptyPlugins(errorMessage: String?, modifier: Modifier = Modifier) {
                 if (errorMessage != null) R.string.plugin_load_failed else R.string.plugin_empty
             ),
             style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             textAlign = TextAlign.Center,
         )
         Spacer(Modifier.height(8.dp))
@@ -570,6 +571,7 @@ private fun ApdNotInstalled() {
         Spacer(Modifier.height(16.dp))
         Text(
             text = stringResource(R.string.plugin_summary_title),
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
             style = MaterialTheme.typography.titleMedium,
             textAlign = TextAlign.Center,
         )


### PR DESCRIPTION
Use onSurfaceVariant for plugin texts
Apply MaterialTheme.colorScheme.onSurfaceVariant to Text components in EmptyPlugins and ApdNotInstalled to improve visual consistency and contrast with the design system.