### PR TITLE
feat(shizuku): 内置 Shizuku Server 全量日志功能

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/ShizukuLogScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/ShizukuLogScreen.kt
@@ -1,0 +1,338 @@
+package me.bmax.apatch.ui.screen.settings
+
+import android.content.Intent
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Article
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.DeleteSweep
+import androidx.compose.material.icons.outlined.Refresh
+import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.FileProvider
+import com.ramcosta.composedestinations.annotation.Destination
+import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.navigation.DestinationsNavigator
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import me.bmax.apatch.R
+import me.bmax.apatch.util.ShizukuServiceManager
+import me.bmax.apatch.util.ui.showToast
+import java.io.File
+
+/** 日志来源：server 持久化日志 / 系统 logcat。 */
+private enum class LogSource { SERVER, LOGCAT }
+
+/** 一行日志及其解析出的级别。 */
+private data class LogLine(val level: Char, val text: String)
+
+private val LEVELS = listOf('V', 'D', 'I', 'W', 'E')
+
+/** 从一行文本解析日志级别，形如 "... I/tag: msg" 或 logcat 的 "... I/tag(pid): msg"。 */
+private fun parseLevel(line: String): Char {
+    // 找第一个形如 " X/" 的位置（X 为级别字母）
+    var i = 0
+    while (i < line.length - 1) {
+        val c = line[i]
+        if ((c == 'V' || c == 'D' || c == 'I' || c == 'W' || c == 'E' || c == 'A')
+            && line[i + 1] == '/'
+            && (i == 0 || line[i - 1] == ' ')
+        ) {
+            return c
+        }
+        i++
+    }
+    return '?'
+}
+
+private fun parseLines(raw: String): List<LogLine> {
+    if (raw.isBlank()) return emptyList()
+    return raw.split('\n')
+        .filter { it.isNotBlank() }
+        .map { LogLine(parseLevel(it), it) }
+}
+
+@Destination<RootGraph>
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ShizukuLogScreen(navigator: DestinationsNavigator) {
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
+
+    var source by remember { mutableStateOf(LogSource.SERVER) }
+    var allLines by remember { mutableStateOf<List<LogLine>>(emptyList()) }
+    var isLoading by remember { mutableStateOf(true) }
+    var query by remember { mutableStateOf("") }
+    // 选中的级别过滤；空集合表示全部显示。
+    var activeLevels by remember { mutableStateOf<Set<Char>>(emptySet()) }
+
+    val listState = rememberLazyListState()
+
+    fun refresh() {
+        scope.launch {
+            isLoading = true
+            val raw = withContext(Dispatchers.IO) {
+                when (source) {
+                    LogSource.SERVER -> ShizukuServiceManager.getServerLog()
+                    LogSource.LOGCAT -> ShizukuServiceManager.getLogcat()
+                }
+            }
+            allLines = parseLines(raw)
+            isLoading = false
+        }
+    }
+
+    LaunchedEffect(source) { refresh() }
+
+    val visibleLines = remember(allLines, query, activeLevels) {
+        allLines.filter { line ->
+            (activeLevels.isEmpty() || line.level in activeLevels) &&
+                (query.isBlank() || line.text.contains(query, ignoreCase = true))
+        }
+    }
+
+    // 新数据到达后滚动到底部（最新日志）
+    LaunchedEffect(visibleLines.size, isLoading) {
+        if (!isLoading && visibleLines.isNotEmpty()) {
+            listState.scrollToItem(visibleLines.size - 1)
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = {
+                    Text(
+                        text = stringResource(R.string.shizuku_log_title),
+                        style = MaterialTheme.typography.titleLarge,
+                        fontWeight = FontWeight.SemiBold,
+                    )
+                },
+                navigationIcon = {
+                    IconButton(onClick = { navigator.popBackStack() }) {
+                        Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = { refresh() }) {
+                        Icon(Icons.Outlined.Refresh, contentDescription = stringResource(R.string.shizuku_log_refresh))
+                    }
+                    IconButton(onClick = {
+                        val text = visibleLines.joinToString("\n") { it.text }
+                        if (text.isBlank()) {
+                            showToast(context, context.getString(R.string.shizuku_log_empty))
+                        } else {
+                            clipboard.setText(AnnotatedString(text))
+                            showToast(context, context.getString(R.string.shizuku_log_copied))
+                        }
+                    }) {
+                        Icon(Icons.Outlined.ContentCopy, contentDescription = stringResource(R.string.shizuku_log_copy))
+                    }
+                    IconButton(onClick = {
+                        scope.launch {
+                            val text = withContext(Dispatchers.IO) {
+                                buildString {
+                                    append("==== Shizuku server log ====\n")
+                                    append(ShizukuServiceManager.getServerLog())
+                                    append("\n\n==== logcat (shizuku tags) ====\n")
+                                    append(ShizukuServiceManager.getLogcat())
+                                }
+                            }
+                            if (text.isBlank()) {
+                                showToast(context, context.getString(R.string.shizuku_log_empty))
+                                return@launch
+                            }
+                            val file = File(context.cacheDir, "shizuku_log.txt")
+                            file.writeText(text)
+                            val uri = FileProvider.getUriForFile(
+                                context, "${context.packageName}.fileprovider", file
+                            )
+                            val shareIntent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_STREAM, uri)
+                                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                            }
+                            context.startActivity(
+                                Intent.createChooser(shareIntent, context.getString(R.string.shizuku_log_export))
+                            )
+                        }
+                    }) {
+                        Icon(Icons.Outlined.Share, contentDescription = stringResource(R.string.shizuku_log_export))
+                    }
+                    IconButton(onClick = {
+                        scope.launch {
+                            withContext(Dispatchers.IO) { ShizukuServiceManager.clearServerLog() }
+                            showToast(context, context.getString(R.string.shizuku_log_cleared))
+                            refresh()
+                        }
+                    }) {
+                        Icon(Icons.Outlined.DeleteSweep, contentDescription = stringResource(R.string.shizuku_log_clear))
+                    }
+                },
+                scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(),
+            )
+        },
+        containerColor = Color.Transparent,
+    ) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            // 来源切换
+            SingleChoiceSegmentedButtonRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+            ) {
+                SegmentedButton(
+                    selected = source == LogSource.SERVER,
+                    onClick = { source = LogSource.SERVER },
+                    shape = SegmentedButtonDefaults.itemShape(index = 0, count = 2),
+                ) { Text(stringResource(R.string.shizuku_log_source_server)) }
+                SegmentedButton(
+                    selected = source == LogSource.LOGCAT,
+                    onClick = { source = LogSource.LOGCAT },
+                    shape = SegmentedButtonDefaults.itemShape(index = 1, count = 2),
+                ) { Text(stringResource(R.string.shizuku_log_source_logcat)) }
+            }
+
+            // 级别过滤
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .horizontalScroll(rememberScrollState())
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                LEVELS.forEach { level ->
+                    FilterChip(
+                        selected = level in activeLevels,
+                        onClick = {
+                            activeLevels = if (level in activeLevels) {
+                                activeLevels - level
+                            } else {
+                                activeLevels + level
+                            }
+                        },
+                        label = { Text(level.toString(), color = levelColor(level)) },
+                    )
+                }
+            }
+
+            // 搜索
+            OutlinedTextField(
+                value = query,
+                onValueChange = { query = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp),
+                singleLine = true,
+                leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
+                placeholder = { Text(stringResource(R.string.shizuku_log_search_hint)) },
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+            )
+
+            when {
+                isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                visibleLines.isEmpty() -> Column(
+                    modifier = Modifier.fillMaxSize().padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.Article,
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.size(56.dp),
+                    )
+                    Spacer(Modifier.height(16.dp))
+                    Text(
+                        text = stringResource(R.string.shizuku_log_empty),
+                        style = MaterialTheme.typography.titleMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                else -> LazyColumn(
+                    state = listState,
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
+                ) {
+                    items(visibleLines) { line ->
+                        Text(
+                            text = line.text,
+                            style = MaterialTheme.typography.bodySmall,
+                            fontFamily = FontFamily.Monospace,
+                            fontSize = 11.sp,
+                            color = levelColor(line.level),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .horizontalScroll(rememberScrollState())
+                                .padding(vertical = 1.dp),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun levelColor(level: Char): Color = when (level) {
+    'E' -> MaterialTheme.colorScheme.error
+    'W' -> Color(0xFFE29A2E)
+    'I' -> MaterialTheme.colorScheme.onSurface
+    'D' -> MaterialTheme.colorScheme.onSurfaceVariant
+    'V' -> MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f)
+    else -> MaterialTheme.colorScheme.onSurfaceVariant
+}

--- a/app/src/main/java/me/bmax/apatch/ui/screen/settings/ShizukuManagementScreen.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/settings/ShizukuManagementScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
+import androidx.compose.material.icons.automirrored.outlined.Article
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.outlined.Shield
 import androidx.compose.material3.Button
@@ -54,6 +55,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
+import com.ramcosta.composedestinations.generated.destinations.ShizukuLogScreenDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -128,6 +130,16 @@ fun ShizukuManagementScreen(navigator: DestinationsNavigator) {
                 navigationIcon = {
                     IconButton(onClick = navigator::popBackStack) {
                         Icon(Icons.AutoMirrored.Outlined.ArrowBack, contentDescription = null)
+                    }
+                },
+                actions = {
+                    IconButton(onClick = {
+                        navigator.navigate(ShizukuLogScreenDestination)
+                    }) {
+                        Icon(
+                            Icons.AutoMirrored.Outlined.Article,
+                            contentDescription = stringResource(R.string.shizuku_log_title),
+                        )
                     }
                 },
             )

--- a/app/src/main/java/me/bmax/apatch/util/ShizukuServiceManager.kt
+++ b/app/src/main/java/me/bmax/apatch/util/ShizukuServiceManager.kt
@@ -322,4 +322,112 @@ object ShizukuServiceManager {
             false
         }
     }
+
+    // ==================== 日志读取 ====================
+
+    /** server 持久化日志文件路径（与 shizuku.json 同级，跨重启保留）。 */
+    private const val SERVER_LOG_FILE = "/data/user_de/0/com.android.shell/shizuku_folk.log"
+    private const val SERVER_LOG_FILE_BACKUP = "/data/user_de/0/com.android.shell/shizuku_folk.log.1"
+
+    /** server 日志在 logcat 中的 tag（Logger 的 tag），用于补充抓取更完整的上下文。 */
+    private val LOGCAT_TAGS = arrayOf(
+        "Service", "ConfigManager", "ClientManager", "UserServiceManager",
+        "ShizukuService", "Starter", "AppProcess",
+    )
+
+    /**
+     * 读取 server 持久化日志。
+     *
+     * 优先走 binder（server 存活时最快、含内存缓冲的最新行）；binder 不可达时
+     * 回退到 root 直接读日志文件——这样即使 server 崩溃/无法启动，也能看到上次
+     * 会话留下的日志（排查"配置为什么消失""server 为什么起不来"的关键）。
+     */
+    fun getServerLog(): String {
+        if (Shizuku.pingBinder()) {
+            val viaBinder = getLogViaBinder()
+            if (viaBinder != null) return viaBinder
+        }
+        return readLogFileViaRoot()
+    }
+
+    private fun getLogViaBinder(): String? {
+        val data = Parcel.obtain()
+        val reply = Parcel.obtain()
+        return try {
+            data.writeInterfaceToken("moe.shizuku.server.IShizukuService")
+            Shizuku.getBinder()!!.transact(ServerConstants.BINDER_TRANSACTION_getLog, data, reply, 0)
+            reply.readException()
+            reply.readString().orEmpty()
+        } catch (t: Throwable) {
+            Log.e(TAG, "getLog via binder failed", t)
+            null
+        } finally {
+            reply.recycle()
+            data.recycle()
+        }
+    }
+
+    /** root 直接读取日志文件（含轮转备份），server 不可达时的兜底。 */
+    private fun readLogFileViaRoot(): String {
+        return try {
+            val out = ArrayList<String>()
+            val err = ArrayList<String>()
+            getRootShell().newJob()
+                .add("cat $SERVER_LOG_FILE_BACKUP 2>/dev/null; cat $SERVER_LOG_FILE 2>/dev/null")
+                .to(out, err)
+                .exec()
+            out.joinToString("\n")
+        } catch (t: Throwable) {
+            Log.e(TAG, "readLogFileViaRoot failed", t)
+            ""
+        }
+    }
+
+    /**
+     * 抓取 logcat 中与 Shizuku server 相关 tag 的实时日志，补充 binder/文件之外的
+     * 系统侧上下文（如 ART/zygote abort、SELinux denial 等启动早期问题）。
+     */
+    fun getLogcat(): String {
+        return try {
+            val out = ArrayList<String>()
+            val err = ArrayList<String>()
+            val filter = LOGCAT_TAGS.joinToString(" ") { "$it:V" }
+            getRootShell().newJob()
+                .add("logcat -d -v time -t 2000 $filter *:S 2>/dev/null")
+                .to(out, err)
+                .exec()
+            out.joinToString("\n")
+        } catch (t: Throwable) {
+            Log.e(TAG, "getLogcat failed", t)
+            ""
+        }
+    }
+
+    /** 清空 server 持久化日志（binder 优先，兜底 root 删文件）。 */
+    fun clearServerLog(): Boolean {
+        if (Shizuku.pingBinder()) {
+            val data = Parcel.obtain()
+            val reply = Parcel.obtain()
+            try {
+                data.writeInterfaceToken("moe.shizuku.server.IShizukuService")
+                Shizuku.getBinder()!!.transact(ServerConstants.BINDER_TRANSACTION_clearLog, data, reply, 0)
+                reply.readException()
+                return true
+            } catch (t: Throwable) {
+                Log.e(TAG, "clearLog via binder failed", t)
+            } finally {
+                reply.recycle()
+                data.recycle()
+            }
+        }
+        return try {
+            getRootShell().newJob()
+                .add("rm -f $SERVER_LOG_FILE $SERVER_LOG_FILE_BACKUP")
+                .exec()
+                .isSuccess
+        } catch (t: Throwable) {
+            Log.e(TAG, "clearServerLog via root failed", t)
+            false
+        }
+    }
 }

--- a/app/src/main/java/rikka/shizuku/server/ServerConstants.java
+++ b/app/src/main/java/rikka/shizuku/server/ServerConstants.java
@@ -17,4 +17,10 @@ public class ServerConstants {
 
     /** manager-only：设置某 uid 的分权（shellOnly）标记 */
     public static final int BINDER_TRANSACTION_setShellOnly = 10003;
+
+    /** manager-only：读取 server 持久化日志（返回文本） */
+    public static final int BINDER_TRANSACTION_getLog = 10004;
+
+    /** manager-only：清空 server 持久化日志 */
+    public static final int BINDER_TRANSACTION_clearLog = 10005;
 }

--- a/app/src/main/java/rikka/shizuku/server/ShizukuService.java
+++ b/app/src/main/java/rikka/shizuku/server/ShizukuService.java
@@ -145,7 +145,9 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
 
         HandlerUtil.setMainHandler(mainHandler);
 
-        LOGGER.i("starting server...");
+        LOGGER.i("======== shizuku server session start ========");
+        LOGGER.i("starting server... uid=%d pid=%d secontext=%s",
+                OsUtils.getUid(), OsUtils.getPid(), OsUtils.getSELinuxContext());
 
         waitSystemService("package");
         waitSystemService(Context.ACTIVITY_SERVICE);
@@ -586,6 +588,23 @@ public class ShizukuService extends Service<ShizukuUserServiceManager, ShizukuCl
                 LOGGER.i("setShellOnly(%d, %s): restart user services for %s",
                         uid, Boolean.toString(shellOnly), record.packageName);
             }
+            reply.writeNoException();
+            return true;
+        } else if (code == ServerConstants.BINDER_TRANSACTION_getLog) {
+            data.enforceInterface(ShizukuApiConstants.BINDER_DESCRIPTOR);
+            if (UserHandleCompat.getAppId(Binder.getCallingUid()) != managerAppId) {
+                throw new SecurityException("getLog is allowed to be called only from the manager");
+            }
+            reply.writeNoException();
+            reply.writeString(rikka.shizuku.server.util.ServerLog.dump());
+            return true;
+        } else if (code == ServerConstants.BINDER_TRANSACTION_clearLog) {
+            data.enforceInterface(ShizukuApiConstants.BINDER_DESCRIPTOR);
+            if (UserHandleCompat.getAppId(Binder.getCallingUid()) != managerAppId) {
+                throw new SecurityException("clearLog is allowed to be called only from the manager");
+            }
+            rikka.shizuku.server.util.ServerLog.clear();
+            LOGGER.i("log cleared by manager");
             reply.writeNoException();
             return true;
         }

--- a/app/src/main/java/rikka/shizuku/server/util/Logger.java
+++ b/app/src/main/java/rikka/shizuku/server/util/Logger.java
@@ -139,6 +139,8 @@ public class Logger {
         if (LOGGER != null) {
             LOGGER.info(msg);
         }
+        // 汇聚到持久化日志，供 manager 端读取与"配置为什么消失"之类问题排查。
+        ServerLog.append(priority, tag, msg);
         return Log.println(priority, tag, msg);
     }
 }

--- a/app/src/main/java/rikka/shizuku/server/util/ServerLog.java
+++ b/app/src/main/java/rikka/shizuku/server/util/ServerLog.java
@@ -1,0 +1,208 @@
+package rikka.shizuku.server.util;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.text.SimpleDateFormat;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Locale;
+
+/**
+ * 内置 Shizuku Server 的持久化日志汇聚点。
+ *
+ * <p>所有经过 {@link Logger#println} 的日志都会在此留存两份：
+ * <ul>
+ *   <li>内存环形缓冲（最近 {@link #MEM_MAX_LINES} 行），供 binder 快速读取；</li>
+ *   <li>磁盘文件 {@link #LOG_FILE}，跨 server 重启保留，用于排查"配置为什么消失"
+ *       之类跨进程/跨重启的问题（logcat 会随重启或轮转丢失）。</li>
+ * </ul>
+ *
+ * <p>文件写在 shell 的 de 目录（与 shizuku.json 同级），server 无论以 root 还是 shell
+ * 身份运行都可读写；超过 {@link #FILE_MAX_BYTES} 时轮转一次到 {@code .1}，磁盘占用有上限。
+ *
+ * <p>本类只被 server 进程使用；manager 侧通过 binder 事务或 root 直接读取 {@link #LOG_FILE}。
+ */
+public final class ServerLog {
+
+    private ServerLog() {
+    }
+
+    /** 与 shizuku.json 同级，server（root/shell）均可读写。 */
+    public static final File LOG_DIR = new File("/data/user_de/0/com.android.shell");
+    public static final File LOG_FILE = new File(LOG_DIR, "shizuku_folk.log");
+    private static final File LOG_FILE_BACKUP = new File(LOG_DIR, "shizuku_folk.log.1");
+
+    /** 单文件上限 512 KiB，超出后轮转一次；连同 .1 备份磁盘占用 ≤ ~1 MiB。 */
+    private static final long FILE_MAX_BYTES = 512 * 1024;
+    /** 内存环形缓冲行数上限。 */
+    private static final int MEM_MAX_LINES = 2000;
+    /** binder 单次事务返回上限（避免超过 1 MiB binder 限制），返回文件末尾这么多字节。 */
+    private static final int DUMP_MAX_BYTES = 256 * 1024;
+
+    private static final Object LOCK = new Object();
+    private static final Deque<String> MEM = new ArrayDeque<>(MEM_MAX_LINES);
+    private static final SimpleDateFormat TIME_FMT =
+            new SimpleDateFormat("MM-dd HH:mm:ss.SSS", Locale.ENGLISH);
+
+    private static FileOutputStream fileStream;
+    private static boolean fileInitTried;
+
+    private static char levelChar(int priority) {
+        switch (priority) {
+            case Log.VERBOSE: return 'V';
+            case Log.DEBUG:   return 'D';
+            case Log.INFO:    return 'I';
+            case Log.WARN:    return 'W';
+            case Log.ERROR:   return 'E';
+            case Log.ASSERT:  return 'A';
+            default:          return '?';
+        }
+    }
+
+    /** 由 {@link Logger#println} 调用：把一条日志写入内存缓冲与磁盘文件。 */
+    public static void append(int priority, String tag, String msg) {
+        if (msg == null) {
+            msg = "";
+        }
+        String line = TIME_FMT.format(new java.util.Date())
+                + ' ' + levelChar(priority) + '/' + tag + ": " + msg;
+        synchronized (LOCK) {
+            if (MEM.size() >= MEM_MAX_LINES) {
+                MEM.pollFirst();
+            }
+            MEM.addLast(line);
+            writeFileLocked(line);
+        }
+    }
+
+    private static void writeFileLocked(String line) {
+        try {
+            if (!fileInitTried) {
+                fileInitTried = true;
+                openFileLocked();
+            }
+            if (fileStream == null) {
+                return;
+            }
+            rotateIfNeededLocked();
+            if (fileStream == null) {
+                openFileLocked();
+                if (fileStream == null) {
+                    return;
+                }
+            }
+            fileStream.write((line + '\n').getBytes());
+            fileStream.flush();
+        } catch (Throwable ignored) {
+            // 日志落盘失败不能影响 server 正常运行；内存缓冲仍可用。
+        }
+    }
+
+    private static void openFileLocked() {
+        try {
+            if (!LOG_DIR.isDirectory()) {
+                // 目录理论上一定存在（shizuku.json 所在），缺失时也尽力创建。
+                //noinspection ResultOfMethodCallIgnored
+                LOG_DIR.mkdirs();
+            }
+            fileStream = new FileOutputStream(LOG_FILE, true /* append */);
+            //noinspection ResultOfMethodCallIgnored
+            LOG_FILE.setReadable(true, false);
+        } catch (IOException e) {
+            fileStream = null;
+        }
+    }
+
+    private static void rotateIfNeededLocked() {
+        try {
+            if (LOG_FILE.length() < FILE_MAX_BYTES) {
+                return;
+            }
+            if (fileStream != null) {
+                try {
+                    fileStream.close();
+                } catch (IOException ignored) {
+                }
+                fileStream = null;
+            }
+            //noinspection ResultOfMethodCallIgnored
+            LOG_FILE_BACKUP.delete();
+            //noinspection ResultOfMethodCallIgnored
+            LOG_FILE.renameTo(LOG_FILE_BACKUP);
+            openFileLocked();
+        } catch (Throwable ignored) {
+        }
+    }
+
+    /**
+     * 返回持久化日志文本（末尾最多 {@link #DUMP_MAX_BYTES} 字节）。
+     * 优先读磁盘文件（含本次启动前的历史），文件不可用时回退到内存缓冲。
+     */
+    public static String dump() {
+        synchronized (LOCK) {
+            String fromFile = readFileTailLocked();
+            if (fromFile != null && !fromFile.isEmpty()) {
+                return fromFile;
+            }
+            if (MEM.isEmpty()) {
+                return "";
+            }
+            StringBuilder sb = new StringBuilder();
+            for (String l : MEM) {
+                sb.append(l).append('\n');
+            }
+            return sb.toString();
+        }
+    }
+
+    private static String readFileTailLocked() {
+        if (!LOG_FILE.isFile()) {
+            return null;
+        }
+        try (RandomAccessFile raf = new RandomAccessFile(LOG_FILE, "r")) {
+            long len = raf.length();
+            long start = Math.max(0, len - DUMP_MAX_BYTES);
+            raf.seek(start);
+            byte[] buf = new byte[(int) (len - start)];
+            raf.readFully(buf);
+            String text = new String(buf);
+            if (start > 0) {
+                int nl = text.indexOf('\n');
+                if (nl >= 0 && nl + 1 < text.length()) {
+                    // 丢弃被截断的首行残片
+                    text = text.substring(nl + 1);
+                }
+                text = "…(older lines truncated)…\n" + text;
+            }
+            return text;
+        } catch (Throwable e) {
+            return null;
+        }
+    }
+
+    /** 清空内存缓冲与磁盘文件。 */
+    public static void clear() {
+        synchronized (LOCK) {
+            MEM.clear();
+            try {
+                if (fileStream != null) {
+                    try {
+                        fileStream.close();
+                    } catch (IOException ignored) {
+                    }
+                    fileStream = null;
+                }
+                //noinspection ResultOfMethodCallIgnored
+                LOG_FILE.delete();
+                //noinspection ResultOfMethodCallIgnored
+                LOG_FILE_BACKUP.delete();
+                fileInitTried = false;
+            } catch (Throwable ignored) {
+            }
+        }
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -626,6 +626,17 @@ KernelPatch 需要修补 boot 镜像。
     <string name="shizuku_management_badge_denied">未授权</string>
     <string name="shizuku_management_badge_root">ROOT</string>
     <string name="shizuku_management_badge_shell">SHELL</string>
+    <string name="shizuku_log_title">Shizuku 日志</string>
+    <string name="shizuku_log_empty">暂无日志</string>
+    <string name="shizuku_log_refresh">刷新</string>
+    <string name="shizuku_log_clear">清空日志</string>
+    <string name="shizuku_log_cleared">日志已清空</string>
+    <string name="shizuku_log_export">导出日志</string>
+    <string name="shizuku_log_copy">复制</string>
+    <string name="shizuku_log_copied">已复制到剪贴板</string>
+    <string name="shizuku_log_source_server">服务端日志</string>
+    <string name="shizuku_log_source_logcat">Logcat</string>
+    <string name="shizuku_log_search_hint">搜索日志</string>
     <string name="shizuku_permission_title">允许 %1$s 使用 Shizuku 吗？</string>
     <string name="shizuku_permission_message">该应用将通过 Shizuku 以 root 权限调用系统 API</string>
     <string name="shizuku_permission_allow">允许</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -649,6 +649,17 @@ Here are some possible reasons for authentication failure—please check which o
     <string name="shizuku_management_badge_denied">DENIED</string>
     <string name="shizuku_management_badge_root">ROOT</string>
     <string name="shizuku_management_badge_shell">SHELL</string>
+    <string name="shizuku_log_title">Shizuku logs</string>
+    <string name="shizuku_log_empty">No logs</string>
+    <string name="shizuku_log_refresh">Refresh</string>
+    <string name="shizuku_log_clear">Clear logs</string>
+    <string name="shizuku_log_cleared">Logs cleared</string>
+    <string name="shizuku_log_export">Export logs</string>
+    <string name="shizuku_log_copy">Copy</string>
+    <string name="shizuku_log_copied">Copied to clipboard</string>
+    <string name="shizuku_log_source_server">Server log</string>
+    <string name="shizuku_log_source_logcat">Logcat</string>
+    <string name="shizuku_log_search_hint">Search logs</string>
     <string name="shizuku_permission_title">Allow %1$s to use Shizuku?</string>
     <string name="shizuku_permission_message">The app will be able to call system APIs with root privileges through Shizuku.</string>
     <string name="shizuku_permission_allow">Allow</string>


### PR DESCRIPTION
## 背景

内置 Shizuku Server(`rikka.shizuku.server`)此前只把日志打到 logcat,Manager 侧无法读取,且重启后丢失。这导致像"授权配置为什么消失"这类跨进程/跨重启的问题难以排查——实际裁剪逻辑在 `ShizukuConfigManager`(uid 消失、包变化、去重时移除 entry),原因都写进了 `LOGGER`,但用户看不到。

本 PR 补上一套完整的 Shizuku 日志读取能力。

## 设计

在所有 `LOGGER` 调用的唯一出口 `Logger.println` 单点挂钩,**无遗漏地捕获 Service / ConfigManager / ClientManager 等全模块日志**。

### 服务端(特权进程)
- **新增 `ServerLog`**:内存环形缓冲(2000 行)+ 持久化文件 `/data/user_de/0/com.android.shell/shizuku_folk.log`,512KiB 轮转一次(`.1` 备份),**跨 server 重启保留**,可回看上次会话为何裁剪配置。
- **`Logger.println`**:追加一行 `ServerLog.append()`(全捕获点)。
- **`ShizukuService`**:启动时记录会话分隔 + uid/pid/SELinux 上下文;`onTransact` 新增 manager-only 的 `getLog`/`clearLog` binder 事务。
- **`ServerConstants`**:新增事务码 `10004`/`10005`。

### Manager 端
- **`ShizukuServiceManager`**:`getServerLog()`(binder 优先,**不可达时 root 直读文件**,server 崩溃/起不来也能看历史)、`getLogcat()`(补抓 shizuku 相关 tag 的系统 logcat)、`clearServerLog()`。
- **新增 `ShizukuLogScreen`**:服务端日志 / Logcat 切换、V/D/I/W/E 级别过滤、搜索、刷新 / 清空 / 复制 / 分享,按级别着色的等宽显示。
- 入口挂在 Shizuku 授权页右上角。
- 字符串补充 `values/`(英) 与 `values-zh-rCN/`(简中),其余语言回退英文。

## 测试

CI(`assembleDebug`,含 NDK + Rust 全量编译)通过。

## 影响面

- 日志落盘失败不影响 server 正常运行(内存缓冲兜底);磁盘占用有上限(≤ ~1MiB)。
- getLog/clearLog 均校验调用方为 manager,非 manager 抛 SecurityException。
