### PR TITLE
Fix ANSI clear command detection in log display

### DIFF
--- a/app/src/main/java/me/bmax/apatch/ui/screen/ExecuteAPMAction.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/ExecuteAPMAction.kt
@@ -72,7 +72,7 @@ fun ExecuteAPMActionScreen(navigator: DestinationsNavigator, moduleId: String) {
      * The full, untruncated log is kept in [fullLogBuffer] for saving to a file.
      */
     fun appendDisplay(line: String) {
-        if (line.startsWith("\u001B[H\u001BJ")) { // clear command
+        if (line.startsWith("\u001B[H\u001B[J")) { // clear command
             displayBuffer.setLength(0)
             displayBuffer.append(line.substring(6))
         } else {

--- a/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
+++ b/app/src/main/java/me/bmax/apatch/ui/screen/Install.kt
@@ -79,7 +79,7 @@ fun InstallScreen(navigator: DestinationsNavigator, uri: Uri, type: MODULE_TYPE)
      * log is kept in [fullLogBuffer] for saving to a file.
      */
     fun appendDisplay(line: String) {
-        if (line.startsWith("\u001B[H\u001BJ")) { // clear command
+        if (line.startsWith("\u001B[H\u001B[J")) { // clear command
             displayBuffer.setLength(0)
             displayBuffer.append(line.substring(6))
         } else {


### PR DESCRIPTION
Corrects the string used to detect the ANSI clear screen command from '\u001B[H\u001BJ' to '\u001B[H\u001B[J' in both ExecuteAPMActionScreen and InstallScreen. This ensures proper log buffer clearing when the clear command is received.